### PR TITLE
다크모드 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "14.1.0",
+        "next-themes": "^0.2.1",
         "react": "^18",
         "react-dom": "^18",
         "react-icons": "^5.0.1"
@@ -3160,6 +3161,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "next": "14.1.0",
+    "next-themes": "^0.2.1",
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.0.1"

--- a/src/app/[channelId]/Providers.tsx
+++ b/src/app/[channelId]/Providers.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { ThemeProvider } from 'next-themes'
+import { useEffect, useState } from 'react'
+
+export default function Providers({
+  children
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  const [isMount, setMount] = useState(false)
+
+  useEffect(() => {
+    setMount(true)
+  }, [])
+
+  if (!isMount) return null
+
+  return (
+    <ThemeProvider enableSystem={true} attribute='class'>
+      {children}
+    </ThemeProvider>
+  )
+}

--- a/src/app/[channelId]/dashboard/page.tsx
+++ b/src/app/[channelId]/dashboard/page.tsx
@@ -1,12 +1,15 @@
 export default function Dashboard() {
   return (
-    <div className='flex-1 flex gap-5'>
-      <div className='basis-1/3 p-5 rounded-lg bg-[#ffd2d6]/50 shadow-lg shadow-gray-200/50'>다가오는 레이드</div>
-      <div className='flex-1 grid grid-cols-2 gap-5'>
-        <div className='p-5 rounded-lg bg-white/50 shadow-lg shadow-gray-200/50'>1</div>
-        <div className='p-5 rounded-lg bg-white/50 shadow-lg shadow-gray-200/50'>2</div>
-        <div className='p-5 rounded-lg bg-white/50 shadow-lg shadow-gray-200/50'>3</div>
-        <div className='p-5 rounded-lg bg-white/50 shadow-lg shadow-gray-200/50'>4</div>
+    <div className='flex-1 flex gap-5 overflow-hidden'>
+      <div className='card basis-1/3 bg-secondary-accent/50 dark:bg-primary-accent/80'>
+        <div className='pb-4 text-xl'>다가오는 레이드</div>
+        <div className='flex flex-col gap-3'></div>
+      </div>
+      <div className='flex-1 grid grid-cols-2 grid-rows-2 gap-5'>
+        <div className='card'>1</div>
+        <div className='card'>2</div>
+        <div className='card'>3</div>
+        <div className='card'>4</div>
       </div>
     </div>
   )

--- a/src/app/[channelId]/layout.tsx
+++ b/src/app/[channelId]/layout.tsx
@@ -10,7 +10,7 @@ export default function ChannelLayout({
 }>) {
   return (
     <Providers>
-      <div className='h-dvh flex bg-[#f8fafb]'>
+      <div className='h-dvh flex bg-light dark:bg-dark dark:text-light'>
         <SideBar />
         <main className='flex-1 flex flex-col gap-5 p-7 pb-5'>
           <ServerName />

--- a/src/app/[channelId]/layout.tsx
+++ b/src/app/[channelId]/layout.tsx
@@ -1,6 +1,7 @@
 import Navigation from '@/components/layout/Navigation'
 import ServerName from '@/components/layout/ServerName'
 import SideBar from '@/components/layout/sidebar/SideBar'
+import Providers from './Providers'
 
 export default function ChannelLayout({
   children
@@ -8,13 +9,15 @@ export default function ChannelLayout({
   children: React.ReactNode
 }>) {
   return (
-    <div className={`h-dvh flex bg-[#f8fafb]`}>
-      <SideBar />
-      <main className='flex-1 flex flex-col gap-5 p-7 pb-5'>
-        <ServerName />
-        <Navigation />
-        {children}
-      </main>
-    </div>
+    <Providers>
+      <div className='h-dvh flex bg-[#f8fafb]'>
+        <SideBar />
+        <main className='flex-1 flex flex-col gap-5 p-7 pb-5'>
+          <ServerName />
+          <Navigation />
+          {children}
+        </main>
+      </div>
+    </Providers>
   )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,12 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
-html,
-body {
-}
-
 @layer utilities {
   .clip-path-polygon {
     clip-path: polygon(55% 0, 100% 0, 100% 100%, 90% 100%);
+  }
+}
+
+@layer components {
+  .card {
+    @apply p-5 rounded-lg bg-white/50 shadow-lg shadow-gray-200/50 dark:bg-light/5 dark:shadow-neutral-700/10;
   }
 }

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,6 +1,6 @@
 export default function Navigation() {
   return (
-    <nav className='border-b border-gray-200/70'>
+    <nav className='border-b border-secondary-gray/50 dark:border-primary-gray/50'>
       <ul className='flex'>
         <li className='px-4 py-1 border-b-2 border-black font-bold'>대시보드</li>
         <li className='px-4 py-1'>레이드 일정</li>

--- a/src/components/layout/sidebar/SideBar.tsx
+++ b/src/components/layout/sidebar/SideBar.tsx
@@ -1,3 +1,5 @@
+import ThemeButton from './ThemeButton'
+
 export default function SideBar() {
   return (
     <aside className='min-w-72 flex flex-col border-r bg-white border-gray-200/70'>
@@ -7,7 +9,9 @@ export default function SideBar() {
             LoReady
           </a>
         </div>
-        <div>light</div>
+        <div className='flex items-center'>
+          <ThemeButton />
+        </div>
       </header>
       <div className='flex-1 flex flex-col justify-center p-7'>참여중인 서버</div>
       <footer className='flex flex-col gap-5 px-7 py-5 border-t border-gray-200/70'>

--- a/src/components/layout/sidebar/SideBar.tsx
+++ b/src/components/layout/sidebar/SideBar.tsx
@@ -1,8 +1,9 @@
 import ThemeButton from './ThemeButton'
+import { MdEmail } from 'react-icons/md'
 
 export default function SideBar() {
   return (
-    <aside className='min-w-72 flex flex-col border-r bg-white border-gray-200/70'>
+    <aside className='min-w-72 flex flex-col bg-white border-r border-secondary-gray/50 dark:bg-neutral-900 dark:border-primary-gray/50'>
       <header className='flex items-center p-7'>
         <div className='flex-1'>
           <a className='text-2xl text-blue-700' href='/'>
@@ -14,16 +15,16 @@ export default function SideBar() {
         </div>
       </header>
       <div className='flex-1 flex flex-col justify-center p-7'>참여중인 서버</div>
-      <footer className='flex flex-col gap-5 px-7 py-5 border-t border-gray-200/70'>
-        <ul className='flex gap-5 text-base text-gray-700'>
-          <li>
-            <a href='https://github.com/EthanJcoding/LoReady-Web' target='_blank'>
-              GitHub
-            </a>
+      <footer className='flex flex-col gap-5 px-7 py-5 border-t border-inherit'>
+        <ul className='flex gap-5 text-base text-inherit'>
+          <li className='flex items-center gap-1'>
+            <span>
+              <MdEmail size='20' />
+            </span>
+            Contact us
           </li>
-          <li>Contact us</li>
         </ul>
-        <div className='text-xs text-gray-400'>&copy; 2024. LoReady. All rights reserved.</div>
+        <div className='text-xs text-primary-gray'>&copy; 2024. LoReady. All rights reserved.</div>
       </footer>
     </aside>
   )

--- a/src/components/layout/sidebar/ThemeButton.tsx
+++ b/src/components/layout/sidebar/ThemeButton.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { useTheme } from 'next-themes'
+import { MdOutlineLightMode, MdOutlineDarkMode } from 'react-icons/md'
+
+export default function ThemeButton() {
+  const { systemTheme, theme, setTheme } = useTheme()
+  const currentTheme = theme === 'system' ? systemTheme : theme
+
+  const handleClick = () => {
+    setTheme(currentTheme === 'dark' ? 'light' : 'dark')
+  }
+
+  return (
+    <button
+      className='p-1 border border-gray-200/50 rounded-md bg-transparent text-gray-400 hover:bg-gray-50 dark:text-white hover:dark:bg-gray-700'
+      onClick={handleClick}
+    >
+      {currentTheme === 'dark' ? <MdOutlineDarkMode size='26' /> : <MdOutlineLightMode size='26' />}
+    </button>
+  )
+}

--- a/src/components/layout/sidebar/ThemeButton.tsx
+++ b/src/components/layout/sidebar/ThemeButton.tsx
@@ -12,7 +12,7 @@ export default function ThemeButton() {
 
   return (
     <button
-      className='p-1 border border-gray-200/50 rounded-md bg-transparent text-gray-400 hover:bg-gray-50 dark:text-white hover:dark:bg-gray-700'
+      className='p-1 border border-secondary-gray/50 rounded-md bg-transparent text-primary-gray hover:bg-light dark:border-primary-gray/50 dark:text-light hover:dark:bg-dark'
       onClick={handleClick}
     >
       {currentTheme === 'dark' ? <MdOutlineDarkMode size='26' /> : <MdOutlineLightMode size='26' />}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,6 +15,16 @@ const config: Config = {
       },
       fontFamily: {
         pretendard: ['var(--font-pretendard)']
+      },
+      colors: {
+        light: '#f8fafb',
+        dark: '#272727',
+        'primary-gray': '#9b9b9b',
+        'secondary-gray': '#dde1e6',
+        'primary-blue': '#c7e1ee',
+        'secondary-blue': '#edfcff',
+        'primary-accent': '#00a4e8',
+        'secondary-accent': '#ffd2d6'
       }
     }
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}'
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       backgroundImage: {


### PR DESCRIPTION
#### Light Mode
<img width="1920" alt="image" src="https://github.com/EthanJcoding/LoReady-Web/assets/107888594/abcbdc04-3eb2-4e8b-ba1f-2408979efead">

#### Dark Mode
<img width="1920" alt="image" src="https://github.com/EthanJcoding/LoReady-Web/assets/107888594/d36b7c1f-240a-487d-b24b-58b26fba1978">

- `next-themes` 라이브러리와 tailwind의 다크모드 설정을 통해 다크모드 적용
  - 초기에는 사용자의 system에 따라 설정됩니다.
  - 토글 버튼을 통해서 테마를 변경하면 로컬스토리지에 테마값이 추가되고 이후 페이지 방문시에는 로컬스토리지의 값을 참조하여 테마를 적용합니다.
  - 추후 추가되는 컨텐츠들은 추가적인 다크모드 스타일 적용이 필요할 수 있습니다!
    - 저빼고 다 아실거같지만 `className= 'dark:bg-black dark:text-yellow'` 이런식으로 클래스명에 추가하시면 됩니당
- 다크모드 토글 버튼 추가
- `tailwind.config`에 피그마에 있는 컬러팔레트 추가
  - 추가한 컬러들 위주로 사용해서 작업하시면 좋을 것 같습니당
- card 스타일은 반복적으로 사용할듯 해서 component layer에 추가했습니다.
  - 카드 내부 컨텐츠는 어떤게 올지 몰라서 디자인관련 스타일만 추가되어있습니다.
  - 내부 컨텐츠에 따라 `display, position, overflow`등 속성을 추가하시면 됩니다.
- 사이드바에 깃허브 링크는 규식님 의견 반영해서 제외했습니다🙂


**배경색이나 카드색 border색상 같은것들을 나름 고민해서 적용하긴 했습니다만 이상해보이거나 어설퍼보인다면 알려주세요! 이런 감각이 좋은편이 아니라서요..😢**
