### PR TITLE
스케줄 페이지 임시 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "next-themes": "^0.2.1",
         "react": "^18",
         "react-dom": "^18",
-        "react-icons": "^5.0.1"
+        "react-icons": "^5.0.1",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -467,13 +468,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.57",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.57.tgz",
       "integrity": "sha512-ZvQsktJgSYrQiMirAN60y4O/LRevIV8hUzSOSNB6gfR3/o3wCBFQx3sPwIYtuDMeiVgsSS3UzCV26tEzgnfvQw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -493,7 +494,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.21.0",
@@ -1223,7 +1224,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4638,6 +4639,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4860,6 +4869,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.2.tgz",
+      "integrity": "sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next-themes": "^0.2.1",
     "react": "^18",
     "react-dom": "^18",
-    "react-icons": "^5.0.1"
+    "react-icons": "^5.0.1",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/[channelId]/schedule/page.tsx
+++ b/src/app/[channelId]/schedule/page.tsx
@@ -1,4 +1,5 @@
 import CompactRaidCard from '@/components/dashboard/CompactRaidCard'
+import PartyList from '@/components/partyList/PartyList'
 
 export default function Schedule() {
   return (

--- a/src/app/[channelId]/schedule/page.tsx
+++ b/src/app/[channelId]/schedule/page.tsx
@@ -3,8 +3,31 @@ import PartyList from '@/components/partyList/PartyList'
 
 export default function Schedule() {
   return (
-    <div className='flex-1 flex gap-5'>
-      <CompactRaidCard boss='아브렐슈드' date='2024.02.23(금) 22:00' headCount='8/8' leader='v최강준일v' />
+    <div className='flex-1 flex gap-5 flex-wrap'>
+      <div className='border-solid border-2 h-[260px] rounded-md'>
+        <CompactRaidCard boss='아브렐슈드' date='2024.02.23(금) 22:00' headCount='8/8' leader='v최강준일v' />
+        <PartyList />
+      </div>
+      <div className='border-solid border-2 h-[260px] rounded-md'>
+        <CompactRaidCard boss='쿠크세이튼' date='2024.02.23(금) 23:00' headCount='8/8' leader='v최강준일v' />
+        <PartyList />
+      </div>
+      <div className='border-solid border-2 h-[260px] rounded-md'>
+        <CompactRaidCard boss='일리아칸' date='2024.02.23(금) 22:00' headCount='8/8' leader='v최강준일v' />
+        <PartyList />
+      </div>
+      <div className='border-solid border-2 h-[260px] rounded-md'>
+        <CompactRaidCard boss='발탄' date='2024.02.23(금) 22:00' headCount='8/8' leader='v최강준일v' />
+        <PartyList />
+      </div>
+      <div className='border-solid border-2 h-[260px] rounded-md'>
+        <CompactRaidCard boss='비아키스' date='2024.02.23(금) 22:00' headCount='8/8' leader='v최강준일v' />
+        <PartyList />
+      </div>
+      <div className='border-solid border-2 h-[260px] rounded-md'>
+        <CompactRaidCard boss='카멘' date='2024.02.23(금) 22:00' headCount='8/8' leader='v최강준일v' />
+        <PartyList />
+      </div>
     </div>
   )
 }

--- a/src/components/partyList/PartyList.tsx
+++ b/src/components/partyList/PartyList.tsx
@@ -1,0 +1,45 @@
+'use client'
+import { create } from 'zustand'
+type Store = {
+  party1: {
+    name: string
+  }[]
+  party2: {
+    name: string
+  }[]
+}
+
+const useStore = create<Store>(() => ({
+  party1: [
+    { name: '파이어베이스장인' },
+    { name: '쉽지않은파이어베이스' },
+    { name: '할수있다파이어베이스' },
+    { name: '킹갓준일님' }
+  ],
+  party2: [{ name: 'v최강준일v' }, { name: '달래비빔밥' }, { name: '어묵탕탕수육' }, { name: '로레디짱' }]
+}))
+
+export default function PartyList() {
+  const { party1, party2 } = useStore()
+
+  return (
+    <div className='grid gap-4 grid-cols-2 pt-2 px-3 '>
+      <ul className=' grid-rows-{1} text-center gap-1'>
+        <li className='bg-lime-400 rounded-md font-bold text-white'>1번파티</li>
+        {party1.map((party, index) => (
+          <li className='bg-slate-300 mt-1 rounded-md' key={index}>
+            {party.name}
+          </li>
+        ))}
+      </ul>
+      <ul className='grid-rows-{2} text-center'>
+        <li className='bg-violet-600 rounded-md font-bold text-white'>2번파티</li>
+        {party2.map((party, index) => (
+          <li className='bg-slate-300 mt-1 rounded-md' key={index}>
+            {party.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION

<img width="1009" alt="스크린샷 2024-03-07 오후 11 06 44" src="https://github.com/EthanJcoding/LoReady-Web/assets/106420520/97c27fe1-b954-4e67-a428-70a8139621f2">

서버명아래에 대시보드대신 레이드 일정이 클릭된것처럼 보여야하는부분은 제가 지금 체크해서 빠르게 수정하겠습니다.

zustand를 사용해보고자 임시로 데이터를 만들었습니다.
 1. 우선 임시로 partList컴포넌트라고 이름을 지정했는데 햇갈리거나, 좋은 이름이있다면 바꾸겠습니다(추천 부탁드립니다.)
 2. 아직 무한스크롤기능을 추가하지않아, 스크롤 다운시 브라우저 전체가 스크롤이 됩니다.
 3. 규식님이 올려주신 <CompactRaidCard> 컴포넌트는 최대한 건들지않고 사용해보고자 넣었습니다.
 4. 임시로 만들었기에 클릭해도 레이드 상세로 이동하지않습니다.