### PR TITLE
사이드바 서버리스트

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.discordapp.com',
+        pathname: '**'
+      }
+    ]
+  }
+}
 
 export default nextConfig;

--- a/src/components/layout/sidebar/ServerList.tsx
+++ b/src/components/layout/sidebar/ServerList.tsx
@@ -1,0 +1,25 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+export default function ServerList() {
+  return (
+    <li className='flex opacity-85 hover:opacity-100 transition-opacity'>
+      <Link href={'/1/dashboard'} className='flex items-center gap-2'>
+        <span className='relative block w-6 h-6 rounded-full border overflow-hidden'>
+          <Image
+            src={'https://cdn.discordapp.com/icons/1209059689657016371/0f0a953c0d6c76e50b88304b1b00032e'}
+            alt='서버 아이콘'
+            fill
+            sizes='100px'
+            style={{
+              objectFit: 'cover'
+            }}
+            placeholder='blur'
+            blurDataURL='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8+vx1PQAIqAM4jZDFJQAAAABJRU5ErkJggg==s'
+          ></Image>
+        </span>
+        <span className='max-w-48 truncate'>올바른취업생활</span>
+      </Link>
+    </li>
+  )
+}

--- a/src/components/layout/sidebar/ServerList.tsx
+++ b/src/components/layout/sidebar/ServerList.tsx
@@ -5,15 +5,13 @@ export default function ServerList() {
   return (
     <li className='flex opacity-85 hover:opacity-100 transition-opacity'>
       <Link href={'/1/dashboard'} className='flex items-center gap-2'>
-        <span className='relative block w-6 h-6 rounded-full border overflow-hidden'>
+        <span className='w-6 h-6 rounded-full border overflow-hidden'>
           <Image
+            className='w-full h-full object-cover'
             src={'https://cdn.discordapp.com/icons/1209059689657016371/0f0a953c0d6c76e50b88304b1b00032e'}
             alt='서버 아이콘'
-            fill
-            sizes='100px'
-            style={{
-              objectFit: 'cover'
-            }}
+            width={100}
+            height={100}
             placeholder='blur'
             blurDataURL='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8+vx1PQAIqAM4jZDFJQAAAABJRU5ErkJggg==s'
           ></Image>

--- a/src/components/layout/sidebar/ServerLists.tsx
+++ b/src/components/layout/sidebar/ServerLists.tsx
@@ -1,0 +1,9 @@
+import ServerList from './ServerList'
+
+export default function ServerLists() {
+  return (
+    <ul className='flex flex-col gap-3'>
+      <ServerList />
+    </ul>
+  )
+}

--- a/src/components/layout/sidebar/SideBar.tsx
+++ b/src/components/layout/sidebar/SideBar.tsx
@@ -1,5 +1,7 @@
+import ServerLists from './ServerLists'
 import ThemeButton from './ThemeButton'
 import { MdEmail } from 'react-icons/md'
+import { BsHash } from 'react-icons/bs'
 
 export default function SideBar() {
   return (
@@ -14,7 +16,17 @@ export default function SideBar() {
           <ThemeButton />
         </div>
       </header>
-      <div className='flex-1 flex flex-col justify-center p-7'>참여중인 서버</div>
+      <div className='flex-1 flex flex-col justify-center px-7 py-14 overflow-hidden'>
+        <div className='flex items-center text-sm pb-3'>
+          <span>
+            <BsHash size={18} />
+          </span>
+          참여중인 서버
+        </div>
+        <div className='flex-1 overflow-y-auto'>
+          <ServerLists />
+        </div>
+      </div>
       <footer className='flex flex-col gap-5 px-7 py-5 border-t border-inherit'>
         <ul className='flex gap-5 text-base text-inherit'>
           <li className='flex items-center gap-1'>


### PR DESCRIPTION
**데이터 뿌려주기만 하면 되는데 서버리스트를 보류하기로 한 걸 늦게 알아서 여기까지만 해서 올립니당**

- 서버 아이콘을 디스코드 cdn을 통해서 받을듯 한데 외부이미지라 next.config에 허용하도록 추가했습니다.
- next의 Image 컴포넌트를 fill 속성과 함께 쓰면서 에러는 아니지만 경고메세지가 몇개 떠서 이런저런 레퍼런스를 많이 참고했고 도움이 될 듯하여 공유합니다.
  - `fill` 속성은 `sizes` 속성을 함께 써줘야한다는 경고는 아래 링크 참고했습니다.
    - https://velog.io/@pds0309/nextjs-%EC%B5%9C%EC%86%8C%ED%95%9C%EC%9D%98-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%B5%9C%EC%A0%81%ED%99%94%ED%95%98%EA%B8%B0
  - `objectFit` 속성을 줬을때 legacy prop이다 라는 경고는 아래 next.js 깃헙 examples 참고해서 추가했습니다.
    -  https://github.com/vercel/next.js/blob/canary/examples/image-component/app/fill/page.tsx
  -  외부이미지에 대해서 `blur` 속성을 사용하는 방법
     - https://velog.io/@sangbooom/next.js-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%8A%A4%EC%BC%88%EB%A0%88%ED%86%A4-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0
  - NextJS의 blurDataURL과 base64
    - https://velog.io/@inhwa/NextJS%EC%9D%98blurDataURL%EC%99%80base64

**추가로 궁금하신거나 이상한거 있으시면 코멘트 주십숑!**