### PR TITLE
새로고침 시, nav는 초기화 되고, router는 초기화 되지 않아 서로 불일치하는 버그 해결

### DIFF
--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,7 +1,5 @@
 'use client'
 import Link from 'next/link'
-import { useState } from 'react'
-// import { useRouter } from 'next/router'
 import { usePathname, useRouter } from 'next/navigation'
 
 interface OwnProps {

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,17 +1,10 @@
 'use client'
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
+import { useParams, usePathname } from 'next/navigation'
 
-interface OwnProps {
-  channelId: string
-}
-export default function Navigation({ channelId }: OwnProps) {
-  const router = useRouter()
-
+export default function Navigation() {
+  const { channelId } = useParams()
   const pathname = usePathname()
-  const handleClick = (event: string) => {
-    router.push(`/${channelId}/${event}`)
-  }
 
   return (
     <nav className='border-b border-secondary-gray/50 dark:border-primary-gray/50'>
@@ -19,14 +12,10 @@ export default function Navigation({ channelId }: OwnProps) {
         <li
           className={`px-4 py-1 ${pathname === `/${channelId}/dashboard` ? 'border-b-2 border-black font-bold' : ''}`}
         >
-          <Link href={`/${channelId}/dashboard`} onClick={() => handleClick('dashboard')}>
-            대시보드
-          </Link>
+          <Link href={`/${channelId}/dashboard`}>대시보드</Link>
         </li>
         <li className={`px-4 py-1 ${pathname === `/${channelId}/schedule` ? 'border-b-2 border-black font-bold' : ''}`}>
-          <Link href={`/${channelId}/schedule`} onClick={() => handleClick('schedule')}>
-            레이드 일정
-          </Link>
+          <Link href={`/${channelId}/schedule`}>레이드 일정</Link>
         </li>
       </ul>
     </nav>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,28 +1,31 @@
 'use client'
 import Link from 'next/link'
 import { useState } from 'react'
+// import { useRouter } from 'next/router'
+import { usePathname, useRouter } from 'next/navigation'
 
 interface OwnProps {
   channelId: string
 }
-export default function Navigation() {
-  const [navTap, setNabTap] = useState('dashboard')
+export default function Navigation({ channelId }: OwnProps) {
+  const router = useRouter()
 
+  const pathname = usePathname()
   const handleClick = (event: string) => {
-    setNabTap(event)
+    router.push(`/${channelId}/${event}`)
   }
-
-  const channelId = 'channelId'
 
   return (
     <nav className='border-b border-secondary-gray/50 dark:border-primary-gray/50'>
       <ul className='flex'>
-        <li className={`px-4 py-1 ${navTap === 'dashboard' ? 'border-b-2 border-black font-bold' : ''}`}>
+        <li
+          className={`px-4 py-1 ${pathname === `/${channelId}/dashboard` ? 'border-b-2 border-black font-bold' : ''}`}
+        >
           <Link href={`/${channelId}/dashboard`} onClick={() => handleClick('dashboard')}>
             대시보드
           </Link>
         </li>
-        <li className={`px-4 py-1 ${navTap === 'schedule' ? 'border-b-2 border-black font-bold' : ''}`}>
+        <li className={`px-4 py-1 ${pathname === `/${channelId}/schedule` ? 'border-b-2 border-black font-bold' : ''}`}>
           <Link href={`/${channelId}/schedule`} onClick={() => handleClick('schedule')}>
             레이드 일정
           </Link>

--- a/src/components/partyList/PartyList.tsx
+++ b/src/components/partyList/PartyList.tsx
@@ -1,4 +1,6 @@
 'use client'
+// 파이어베이스에서 데이터 가져오기 : zustand로 가져오기?
+
 import { create } from 'zustand'
 type Store = {
   party1: {
@@ -23,10 +25,10 @@ export default function PartyList() {
   const { party1, party2 } = useStore()
 
   return (
-    <div className='grid grid-cols-2 gap-4 pt-2 px-3 '>
+    <div className='grid grid-cols-2 gap-4 pt-2 px-3 text-center'>
       <div>
-        <div className='bg-lime-400 rounded-md font-bold text-white'>1번파티</div>
-        <ul className='text-center gap-1'>
+        <div className='bg-lime-400 rounded-md font-bold text-white '>1번파티</div>
+        <ul className='gap-1'>
           {party1.map((party, index) => (
             <li className='bg-slate-300 mt-1 rounded-md' key={index}>
               {party.name}
@@ -36,7 +38,7 @@ export default function PartyList() {
       </div>
       <div>
         <div className='bg-violet-600 rounded-md font-bold text-white'>2번파티</div>
-        <ul className='text-center'>
+        <ul className='gap-1'>
           {party2.map((party, index) => (
             <li className='bg-slate-300 mt-1 rounded-md' key={index}>
               {party.name}


### PR DESCRIPTION
### 문제
 + /channelId/schedule 에서 새로고침시 nav는 초기화되고, router는 초기화 되지않아 불일치하는 이슈가 발생했습니다.

### 이유
+  useState의 데이터를 이용하여, css를 관리하였기에 default value로 'dashboard'가 되어있어 새로고침시 nav와 router가 불일치하는 이슈가 발생했습니다.
 
### 해결
+ useParams로 현재 chanddleId를 받아온 후, usePathname를 통해 현재 url이 [channelId]/dahboard인지, [channelId]/schedule 인지 비교후 css를 관리하도록 수정하여 해결했습니다.

+ PartyList 컴포넌트에서 1파티와, 2파티의 텍스트가 중앙정렬이 되지않은 부분 수정했습니다.