### PR TITLE
[대시보드-다가오는레이드] 무한스크롤 적용

### DIFF
--- a/src/api/firebase/getChannelSchedule/getChannelSchedule.ts
+++ b/src/api/firebase/getChannelSchedule/getChannelSchedule.ts
@@ -1,0 +1,56 @@
+import { DocumentData, collection, getDocs, limit, orderBy, query, startAfter, where } from 'firebase/firestore'
+import { firestore } from '../config'
+
+interface Schedule {
+  created: string
+  raidLeader: Character
+  raidType: string
+  isActive: boolean
+  createdBy: string
+  updated: string
+  raidDate: string
+  raidName: string
+  participants: string[]
+  characters: Characters
+  channel: string
+}
+
+interface Characters {
+  party0: Character[]
+  party2: Character[]
+  party1: Character[]
+}
+
+interface Character {
+  character: string
+  userId: string
+}
+
+export interface ScheduleData extends Schedule {
+  id: string
+}
+
+export const getChannelSchedule = async (channelId: string, lastSnap?: DocumentData) => {
+  let scheduleQuery = query(
+    collection(firestore, 'schedules'),
+    where('channel', '==', channelId),
+    orderBy('raidDate', 'desc')
+  )
+
+  if (lastSnap) scheduleQuery = query(scheduleQuery, startAfter(lastSnap))
+
+  scheduleQuery = query(scheduleQuery, limit(10))
+
+  try {
+    const snapshot = await getDocs(scheduleQuery)
+
+    if (snapshot.empty) return { data: [], lastSnap: undefined }
+
+    const lastSnap = snapshot.docs[snapshot.docs.length - 1]
+    const data: ScheduleData[] = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as Schedule) }))
+
+    return { data, lastSnap }
+  } catch (error) {
+    throw error
+  }
+}

--- a/src/api/firebase/getChannelSchedule/getChannelSchedule.ts
+++ b/src/api/firebase/getChannelSchedule/getChannelSchedule.ts
@@ -6,7 +6,7 @@ export const getChannelSchedule = async (channelId: string, lastSnap?: DocumentD
   let scheduleQuery = query(
     collection(firestore, 'schedules'),
     where('channel', '==', channelId),
-    orderBy('raidDate', 'desc')
+    orderBy('raidDate', 'asc')
   )
 
   if (lastSnap) scheduleQuery = query(scheduleQuery, startAfter(lastSnap))

--- a/src/api/firebase/getChannelSchedule/getChannelSchedule.ts
+++ b/src/api/firebase/getChannelSchedule/getChannelSchedule.ts
@@ -3,9 +3,12 @@ import { firestore } from '../config'
 import { Schedule, ScheduleWithId } from '@/types/channelSchedule'
 
 export const getChannelSchedule = async (channelId: string, lastSnap?: DocumentData) => {
+  const now = new Date().toISOString()
+
   let scheduleQuery = query(
     collection(firestore, 'schedules'),
     where('channel', '==', channelId),
+    where('raidDate', '>=', now),
     orderBy('raidDate', 'asc')
   )
 

--- a/src/api/firebase/getChannelSchedule/getChannelSchedule.ts
+++ b/src/api/firebase/getChannelSchedule/getChannelSchedule.ts
@@ -1,34 +1,6 @@
 import { DocumentData, collection, getDocs, limit, orderBy, query, startAfter, where } from 'firebase/firestore'
 import { firestore } from '../config'
-
-interface Schedule {
-  created: string
-  raidLeader: Character
-  raidType: string
-  isActive: boolean
-  createdBy: string
-  updated: string
-  raidDate: string
-  raidName: string
-  participants: string[]
-  characters: Characters
-  channel: string
-}
-
-interface Characters {
-  party0: Character[]
-  party2: Character[]
-  party1: Character[]
-}
-
-interface Character {
-  character: string
-  userId: string
-}
-
-export interface ScheduleData extends Schedule {
-  id: string
-}
+import { Schedule, ScheduleWithId } from '@/types/channelSchedule'
 
 export const getChannelSchedule = async (channelId: string, lastSnap?: DocumentData) => {
   let scheduleQuery = query(
@@ -47,7 +19,7 @@ export const getChannelSchedule = async (channelId: string, lastSnap?: DocumentD
     if (snapshot.empty) return { data: [], lastSnap: undefined }
 
     const lastSnap = snapshot.docs[snapshot.docs.length - 1]
-    const data: ScheduleData[] = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as Schedule) }))
+    const data: ScheduleWithId[] = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as Schedule) }))
 
     return { data, lastSnap }
   } catch (error) {

--- a/src/components/dashboard/RaidList.tsx
+++ b/src/components/dashboard/RaidList.tsx
@@ -1,4 +1,3 @@
-import { getScheduleData } from '@/api/firebase'
 import CompactRaidCard from './CompactRaidCard'
 import Link from 'next/link'
 import { extractBossRank } from '@/utils/extractBossRank'
@@ -6,26 +5,36 @@ import { extractCapacity } from '@/utils/extractCapacity'
 
 interface Ownprops {
   scheduleId: string
+  channelId: string
+  raidName: string
+  raidType: string
+  raidLeader: string
+  raidDate: string
+  participants: string[]
 }
 
-export default async function RaidList({ scheduleId }: Ownprops) {
-  const data = await getScheduleData(scheduleId)
-
-  if (!data) return
-
-  const { boss, rank } = extractBossRank(data.raidName)
-  const capacity = extractCapacity(data.raidType)
-  const participants = data.participants.length
+export default function RaidList({
+  scheduleId,
+  channelId,
+  raidName,
+  raidType,
+  raidLeader,
+  raidDate,
+  participants
+}: Ownprops) {
+  const { boss, rank } = extractBossRank(raidName)
+  const capacity = extractCapacity(raidType)
+  const participant = participants.length
 
   return (
     <li>
-      <Link href={`/${data.channel}/schedule/${scheduleId}`}>
+      <Link href={`/${channelId}/schedule/${scheduleId}`}>
         <CompactRaidCard
           boss={boss}
           rank={rank}
-          leader={data.raidLeader.character}
-          date={data.raidDate}
-          headCount={`${participants} / ${capacity}`}
+          leader={raidLeader}
+          date={raidDate}
+          headCount={`${participant} / ${capacity}`}
         />
       </Link>
     </li>

--- a/src/components/dashboard/UpcomingRaid.tsx
+++ b/src/components/dashboard/UpcomingRaid.tsx
@@ -34,8 +34,7 @@ export default function UpcomingRaid({ channelId }: Ownprops) {
 
     if (targetRef.current && isMore) {
       observer = new IntersectionObserver(handleIntersect, {
-        root: rootRef.current,
-        threshold: 1
+        root: rootRef.current
       })
 
       observer.observe(targetRef.current)
@@ -64,11 +63,7 @@ export default function UpcomingRaid({ channelId }: Ownprops) {
             />
           ))}
         </ul>
-        {isMore && (
-          <div className='pb-3 flex justify-center' ref={targetRef}>
-            Loading...
-          </div>
-        )}
+        {isMore && <div ref={targetRef}></div>}
       </div>
     </div>
   )

--- a/src/components/dashboard/UpcomingRaid.tsx
+++ b/src/components/dashboard/UpcomingRaid.tsx
@@ -1,24 +1,74 @@
-import { getChannelData } from '@/api/firebase'
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
 import RaidList from './RaidList'
+import { getChannelSchedule } from '@/api/firebase/getChannelSchedule/getChannelSchedule'
+import { DocumentData } from 'firebase/firestore'
+import { ScheduleWithId } from '@/types/channelSchedule'
+
 interface Ownprops {
   channelId: string
 }
 
-export default async function UpcomingRaid({ channelId }: Ownprops) {
-  const data = await getChannelData(channelId)
+export default function UpcomingRaid({ channelId }: Ownprops) {
+  const [schedules, setSchedules] = useState<ScheduleWithId[]>([])
+  const [lastSnapshot, setLastSnapshot] = useState<DocumentData>()
+  const [isMore, setIsMore] = useState(true)
+  const targetRef = useRef<HTMLDivElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
 
-  if (!data) return
+  useEffect(() => {
+    let observer: IntersectionObserver
+
+    const handleIntersect = ([entry]: IntersectionObserverEntry[]) => {
+      if (entry.isIntersecting && isMore) {
+        getChannelSchedule(channelId, lastSnapshot)
+          .then(res => {
+            setSchedules(prevSchedules => [...prevSchedules, ...res.data])
+            setLastSnapshot(res.lastSnap)
+            setIsMore(res.lastSnap !== undefined)
+          })
+          .catch(error => console.log(error))
+      }
+    }
+
+    if (targetRef.current && isMore) {
+      observer = new IntersectionObserver(handleIntersect, {
+        root: rootRef.current,
+        threshold: 1
+      })
+
+      observer.observe(targetRef.current)
+    }
+
+    return () => observer && observer.disconnect()
+  }, [lastSnapshot])
+
   return (
-    <div className='card flex flex-col min-w-[340px] basis-1/3 p-0 overflow-hidden'>
+    <div className='card flex flex-col min-w-[340px] basis-1/3 p-0 overflow-hidden' ref={rootRef}>
       <div className='relative flex flex-col h-full bg-[#fee2e5] dark:bg-[#0080b7] overflow-y-auto'>
         <div className='flex justify-between p-5 pb-4 text-xl font-medium bg-inherit sticky top-0 left-0 z-20'>
           다가오는 레이드
         </div>
         <ul className='flex flex-col gap-3 px-5 pb-5'>
-          {data.schedules.map((scheduleId: string) => (
-            <RaidList key={scheduleId} scheduleId={scheduleId} />
+          {schedules.map(schedule => (
+            <RaidList
+              key={schedule.id}
+              scheduleId={schedule.id}
+              channelId={schedule.channel}
+              raidName={schedule.raidName}
+              raidType={schedule.raidType}
+              raidLeader={schedule.raidLeader.character}
+              raidDate={schedule.raidDate}
+              participants={schedule.participants}
+            />
           ))}
         </ul>
+        {isMore && (
+          <div className='pb-3 flex justify-center' ref={targetRef}>
+            Loading...
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/types/channelSchedule.ts
+++ b/src/types/channelSchedule.ts
@@ -1,0 +1,28 @@
+export interface ScheduleWithId extends Schedule {
+  id: string
+}
+
+export interface Schedule {
+  created: string
+  raidLeader: Character
+  raidType: string
+  isActive: boolean
+  createdBy: string
+  updated: string
+  raidDate: string
+  raidName: string
+  participants: string[]
+  characters: Characters
+  channel: string
+}
+
+interface Characters {
+  party0: Character[]
+  party2: Character[]
+  party1: Character[]
+}
+
+interface Character {
+  character: string
+  userId: string
+}


### PR DESCRIPTION
intersection observer api 사용해서 무한스크롤 적용했습니다.
- 적용하기 위해서 UpcomingRaid와 RaidList 컴포넌트가  client component로 변경되었습니다.
- `getChannelSchedule()`
  - firebase **query** 이용해서 schedules 컬렉션에서
  - `where('channel', '==', channelId)`  현재 channel에 해당하는 스케줄만 가져옵니다.
  - `where('raidDate', '>=', now)` 현재시간 이후의 스케줄만 가져옵니다.
  - `orderBy('raidDate', 'asc')`  레이드 시작이 빠른순으로 가져옵니다.
  - `startAfter(lastSnap)`  마지막 데이터를 기준으로 추가 요청을 하고 마지막 데이터는 포함하지 않습니다.
  - `limit(10)`  한 번의 요청당 10개씩 가져오도록 되어있습니다.
  - 이 모든것이 가능하도록 하기위해서 파이어베이스에 **복합색인**이라는걸 추가했습니다. 
  (에러 링크 타고가니 알아서 친절하게 추가해주네요 호호🤭)

혹시 테스트를 해보고싶다면🧐
1. RaidList의 `<li>`에 대충 `py-80` 설정
2.  getChannelSchedule의 limit을 1로 설정
3.  쿼리에서 `where('raidDate', '>=', now)` 이부분을 빼거나 db에서 raidDate를 좀 더 미래로 수정하기
4. 테스트해보기